### PR TITLE
Feature : Tasking Manager Stats

### DIFF
--- a/osmsg/app.py
+++ b/osmsg/app.py
@@ -1103,8 +1103,6 @@ def main():
 
             df = pd.merge(df, df_final, on=["name"], how="left")
             df["tm_projects"] = df["tm_projects"].apply(lambda x: ",".join(x))
-            df["tm_mapping_level"] = df["tm_mapping_level"].str.strip().str.lower()
-
             print(df)
 
         if args.summary:

--- a/osmsg/app.py
+++ b/osmsg/app.py
@@ -1092,6 +1092,7 @@ def main():
                 df_merged.groupby(["name"])
                 .agg(
                     {
+                        "tm_mapping_level": "first",
                         "tasks_mapped": "sum",
                         "tasks_validated": "sum",
                         "tasks_total": "sum",
@@ -1102,6 +1103,8 @@ def main():
 
             df = pd.merge(df, df_final, on=["name"], how="left")
             df["tm_projects"] = df["tm_projects"].apply(lambda x: ",".join(x))
+            df["tm_mapping_level"] = df["tm_mapping_level"].str.strip().str.lower()
+
             print(df)
 
         if args.summary:

--- a/osmsg/app.py
+++ b/osmsg/app.py
@@ -1101,7 +1101,7 @@ def main():
             )
 
             df = pd.merge(df, df_final, on=["name"], how="left")
-            df["tm_projects"] = df["tm_projects"].apply(lambda x: ",".join(str(x)))
+            df["tm_projects"] = df["tm_projects"].apply(lambda x: ",".join(x))
             print(df)
 
         if args.summary:

--- a/osmsg/utils.py
+++ b/osmsg/utils.py
@@ -650,5 +650,13 @@ def generate_tm_stats(tm_projects, usernames):
                     tm_user_stats[user_project_key]["tasks_total"] += user["total"]
 
     tm_df = pd.DataFrame(list(tm_user_stats.values()))
-    tm_df = tm_df.groupby(["name", "tm_projects"], as_index=False).sum()
+
+    tm_df = tm_df.groupby(["name", "tm_projects"], as_index=False).agg(
+        {
+            "tm_mapping_level": "first",
+            "tasks_mapped": "sum",
+            "tasks_validated": "sum",
+            "tasks_total": "sum",
+        }
+    )
     return tm_df

--- a/stats/Readme.md
+++ b/stats/Readme.md
@@ -26,5 +26,11 @@ it is a sum of unique tags key that user added , if you add a poi and there are 
 ### feature count ( building , highway , waterway , amenity etc)
 Feature count will be added if it matches the key supplied , if a change has building key it will add it as a  building = 1 similar for all the features irrespective of values 
 
+## Summary Stats 
+Summary stats represents the summary of interval and respective changes. no of users means total no of users on that day/interval , if we summed up it won't match because same user may contribute to second day ! 
+
+## Editor stats 
+On Summary , Editor:count represents the no of osm element change counts for editor , For summary editor is generated from name of apps merging the version numbers
+
 ## TM Stats 
-TM stats are generated on the basis of project id grabbed from the stats. OSMSG looks for presence for hashtag #hotosm-project-* and creates a unique list of project id contributed within timeframe and filters provided . It then queries TM API , with usernames and project id to gather tm task mapped , validated stats . Timeframe bound for tm stats is not currently supported because of limitaion of API , the stats generated for user is all time stats for that project found on hashtags ! 
+TM stats are generated on the basis of project id grabbed from the stats. OSMSG looks for presence for hashtag #hotosm-project-* and creates a unique list of project id contributed within timeframe and filters provided . It then queries TM API , with usernames and project id to gather tm task mapped , validated stats . Timeframe bound for tm stats is not currently supported because of limitaion of API , the stats generated for user for that project id found on hashtags is all time stats! 

--- a/stats/Readme.md
+++ b/stats/Readme.md
@@ -25,3 +25,6 @@ it is a sum of unique tags key that user added , if you add a poi and there are 
 
 ### feature count ( building , highway , waterway , amenity etc)
 Feature count will be added if it matches the key supplied , if a change has building key it will add it as a  building = 1 similar for all the features irrespective of values 
+
+## TM Stats 
+TM stats are generated on the basis of project id grabbed from the stats. OSMSG looks for presence for hashtag #hotosm-project-* and creates a unique list of project id contributed within timeframe and filters provided . It then queries TM API , with usernames and project id to gather tm task mapped , validated stats . Timeframe bound for tm stats is not currently supported because of limitaion of API , the stats generated for user is all time stats for that project found on hashtags ! 


### PR DESCRIPTION
OSMSG now talks to TM api and pulls out the TM Stats for users 
**Limitations** : 
Due to limitation of date filter on tm api , Stats generated for project and user is all time 
**Explanation** : 
for eg : if I run osmsg for last hour , I have contributed to project 1234 in last hour then , OSMSG will pick tm id from my hashtag comment and run TM API for that project with my user name and gather my stats , this stats if i have worked on same project yesterday stats will still be included ! tm stats will be summary of my contributions for that project ! But it won't include my other project contributions if that project is not mapped / validated by me in last_hour , it will only gather and generate the stats for the tm hashtag changeset found for me ! 